### PR TITLE
Add DefaultValue option

### DIFF
--- a/src/pydantic_sweep/__init__.py
+++ b/src/pydantic_sweep/__init__.py
@@ -1,5 +1,6 @@
 from .model import (
     BaseModel,
+    DefaultValue,
     check_model,
     config_chain,
     config_combine,
@@ -12,6 +13,7 @@ from .model import (
 
 __all__ = [
     "BaseModel",
+    "DefaultValue",
     "check_model",
     "config_chain",
     "config_combine",


### PR DESCRIPTION
This adds a No-op to the field function, making it easier to test against default values as part of a parameter sweep.