### PR TITLE
Tuple keys are not validated internally

### DIFF
--- a/src/pydantic_sweep/model.py
+++ b/src/pydantic_sweep/model.py
@@ -176,7 +176,7 @@ def field(path: Path, values: Iterable) -> list[Config]:
     [Model(sub=Sub(x=10, y=6), seed=5), Model(sub=Sub(x=20, y=6), seed=5)]
 
     """
-    path = normalize_path(path)
+    path = normalize_path(path, check_keys=True)
     if isinstance(values, str):
         raise ValueError("values must be iterable, but got a string")
 

--- a/src/pydantic_sweep/utils.py
+++ b/src/pydantic_sweep/utils.py
@@ -29,8 +29,16 @@ def _path_to_str(p: Path, /) -> str:
     return p if isinstance(p, str) else ".".join(p)
 
 
-def normalize_path(path: Path, /) -> StrictPath:
-    """Normalize a path to a tuple of strings."""
+def normalize_path(path: Path, /, *, check_keys: bool = False) -> StrictPath:
+    """Normalize a path to a tuple of strings.
+
+    Parameters
+    ----------
+    path :
+        The path to be normalized.
+    check_keys :
+        If ``True``, also check each individual key in a tuple path.
+    """
     if isinstance(path, str):
         if not re.fullmatch(_STR_PATH_PATTERN, path):
             raise ValueError(
@@ -39,11 +47,12 @@ def normalize_path(path: Path, /) -> StrictPath:
             )
         return tuple(path.split("."))
     else:
-        for p in path:
-            if not re.fullmatch(_STR_KEY_PATTERN, p):
-                raise ValueError(
-                    f"Paths can only contain letters and underscores, got {p}."
-                )
+        if check_keys:
+            for p in path:
+                if not re.fullmatch(_STR_KEY_PATTERN, p):
+                    raise ValueError(
+                        f"Paths can only contain letters and underscores, got {p}."
+                    )
         return tuple(path)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,11 +24,11 @@ def test_normalize_path():
         normalize_path(".a.b")
 
     with pytest.raises(ValueError):
-        normalize_path(("a", "2"))
+        normalize_path(("a", "2"), check_keys=True)
     with pytest.raises(ValueError):
-        normalize_path(("a.b",))
+        normalize_path(("a.b",), check_keys=True)
     with pytest.raises(ValueError):
-        normalize_path(("0a.b",))
+        normalize_path(("0a.b",), check_keys=True)
 
 
 class TestPathsToDict:


### PR DESCRIPTION
Tuple keys will still be checked for `field`, though that is likely to be a rare usecase anyways.