### PR TITLE
Deploy documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,34 @@ jobs:
         run: uv run pytest
 
       - name: Documentation
-        run: uv run --group doc sphinx-build --jobs 2 --fail-on-warning docs docs/_build
+        run: |
+          uv run --group doc \
+            sphinx-build \
+              --jobs 2 \
+              --fail-on-warning docs \
+              -b html \
+              docs/_build/html
+
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs: ["linux-high"]
+    permissions:
+      pages: write      # permissions to deploy to Pages
+      id-token: write   # verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   windows:
     name: "windows"


### PR DESCRIPTION
For now, this deploys the latest documentation to Github pages, irrespective of any releases.