### PR TITLE
configs_combine is made safer

### DIFF
--- a/docs/notebooks/combinations.pctpy
+++ b/docs/notebooks/combinations.pctpy
@@ -109,10 +109,10 @@ which takes as input existing methods:
 """
 
 # %%
-configs = ps.config_combine(xs, ys, chainer=zip)
-print(configs)
-
 import itertools
+
+configs = ps.config_combine(xs, ys, chainer=itertools.chain)
+print(configs)
 
 configs = ps.config_combine(xs, ys, combiner=itertools.product)
 print(configs)

--- a/src/pydantic_sweep/_model.py
+++ b/src/pydantic_sweep/_model.py
@@ -268,7 +268,13 @@ def config_combine(
             raise ValueError("Can only provide `combiner` or `chainer`, not both")
         return [merge_nested_dicts(*combo) for combo in combiner(*configs)]
     elif chainer is not None:
-        return list(chainer(*configs))
+        res = list(chainer(*configs))
+        if not isinstance(res[0], dict):
+            raise ValueError(
+                f"Chained items are not dictionaries, but {type(res[0])}. Are you sure "
+                f"that you passed a valid chainer function? "
+            )
+        return res
     else:
         raise ValueError("Must provide one of `single_out` or `multi_out`")
 


### PR DESCRIPTION
Previously, passing `zip` as a `chainer` method would quietly output erroneous results.