### PR TITLE
DefaultValue is checked for conflicts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,12 @@
 This page summarizes historic changes in the library. Please also see the
 [release page](https://github.com/befelix/pydantic_sweep/releases)
 
+## Unreleased changes on main branch
+
+- `DefaultValue` is checked against conflicting settings the same way as normal values
+- Passing `DefaultValue` to the `default`/`constant` argument of `initialize` works as
+  expected.
+
 ## 0.1
 
 - Initial release

--- a/src/pydantic_sweep/_utils.py
+++ b/src/pydantic_sweep/_utils.py
@@ -8,10 +8,12 @@ from typing import Any, TypeVar
 from pydantic_sweep.types import Config, Path, StrictPath
 
 __all__ = [
+    "items_skip",
     "merge_nested_dicts",
     "nested_dict_at",
     "nested_dict_from_items",
     "nested_dict_get",
+    "nested_dict_items",
     "nested_dict_replace",
     "normalize_path",
     "random_seeds",
@@ -192,6 +194,17 @@ def merge_nested_dicts(*dicts: Config, overwrite: bool = False) -> Config:
             node[final] = value
 
     return res
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def items_skip(items: Iterable[tuple[K, V]], target: Any) -> Iterator[tuple[K, V]]:
+    """Yield items skipping certain targets."""
+    for key, value in items:
+        if value is not target:
+            yield key, value
 
 
 def random_seeds(num: int, *, upper: int = 1000) -> list[int]:

--- a/src/pydantic_sweep/_version.py
+++ b/src/pydantic_sweep/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
Previously, `DefaultValue` was a No-op that could be set multiple times. This could lead to unexpected results when we request a default value, but accidentally overwrite it with a concrete value.

This PR changes the behavior, so that placeholders are kept until the call to `initialize` and checked for conflicts. That way, the behavior should be more consistent overall.