### PR TITLE
DefaultValue pretty print

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 This page summarizes historic changes in the library. Please also see the
 [release page](https://github.com/befelix/pydantic_sweep/releases)
 
-## Unreleased changes on main branch
+## 0.2
 
 - `DefaultValue` is checked against conflicting settings the same way as normal values
 - Passing `DefaultValue` to the `default`/`constant` argument of `initialize` works as

--- a/docs/notebooks/combinations.pctpy
+++ b/docs/notebooks/combinations.pctpy
@@ -36,6 +36,7 @@ possible inputs. Like all the `ps.config_*` functions, we can provide an arbitra
 number of input configurations to this function.
 """
 
+# %%
 configs = ps.config_product(xs, ys, zs)
 print(configs)
 

--- a/src/pydantic_sweep/_model.py
+++ b/src/pydantic_sweep/_model.py
@@ -41,7 +41,14 @@ class BaseModel(pydantic.BaseModel, extra="forbid", validate_assignment=True):
     pass
 
 
-class DefaultValue:
+class NameMetaClass(type):
+    """A metaclass that overwrite cls.__str__ to its name"""
+
+    def __str__(cls) -> str:
+        return cls.__name__
+
+
+class DefaultValue(metaclass=NameMetaClass):
     """Indicator class for a default value in the ``field`` method."""
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Self:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -105,6 +105,8 @@ class TestField:
             class Test(DefaultValue):
                 pass
 
+        assert str(DefaultValue) == "DefaultValue"
+
 
 class TestInitialize:
     def test_basic(self):


### PR DESCRIPTION
Now that default values are part of the config, having them not return nice str outputs is ugly. This makes `print(DefaultValue)` print `DefaultValue`.