### PR TITLE
Model Unions are validated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,12 @@
 This page summarizes historic changes in the library. Please also see the
 [release page](https://github.com/befelix/pydantic_sweep/releases)
 
+## Unreleased changes on main branch
+
+- `BaseModel` gained a custom model_validator that ensures ambiguous union types of
+  pydantic BaseModels
+
+
 ## 0.2
 
 - `DefaultValue` is checked against conflicting settings the same way as normal values

--- a/docs/notebooks/combinations.pctpy
+++ b/docs/notebooks/combinations.pctpy
@@ -11,7 +11,7 @@ but for now we will start with the most basic one: {any}`config_product`.
 """
 
 # %%
-from pprint import pprint as print
+from pprint import pprint
 
 import pydantic_sweep as ps
 
@@ -27,7 +27,7 @@ ys = ps.field("y", [10, 11])
 zs = ps.field("z", [20, 21, 22])
 
 configs = ps.config_product(xs, ys)
-print(configs)
+pprint(configs)
 
 # %% [markdown]
 """
@@ -38,7 +38,7 @@ number of input configurations to this function.
 
 # %%
 configs = ps.config_product(xs, ys, zs)
-print(configs)
+pprint(configs)
 
 # %% [markdown]
 """
@@ -49,7 +49,7 @@ configurations. That is, equivalently to the call above we could have executed
 
 # %%
 configs = ps.config_product(ps.config_product(xs, ys), zs)
-print(configs)
+pprint(configs)
 
 # %% [markdown]
 """
@@ -59,7 +59,7 @@ the incoming configurations:
 """
 # %%
 configs = ps.config_zip(xs, ys)
-print(configs)
+pprint(configs)
 
 # %% [markdown]
 """
@@ -69,10 +69,10 @@ latter operates in a round-robin way taking configurations in turn:
 """
 # %%
 configs = ps.config_chain(ys, zs)
-print(configs)
+pprint(configs)
 
 configs = ps.config_roundrobin(ys, zs)
-print(configs)
+pprint(configs)
 
 # %% [markdown]
 """
@@ -87,7 +87,7 @@ models = ps.initialize(
         zs,
     ),
 )
-print(models)
+pprint(models)
 
 # %% [markdown]
 """
@@ -115,10 +115,10 @@ which takes as input existing methods:
 import itertools
 
 configs = ps.config_combine(xs, ys, chainer=itertools.chain)
-print(configs)
+pprint(configs)
 
 configs = ps.config_combine(xs, ys, combiner=itertools.product)
-print(configs)
+pprint(configs)
 
 # %% [markdown]
 """
@@ -136,8 +136,8 @@ try:
         ps.config_zip(xs, ys),
         ps.field("x", [-1, -2]),
     )
-except Exception as e:
-    print(repr(e))
+except ValueError as e:
+    print(e)
 
 # %% [markdown]
 """

--- a/docs/notebooks/example.pctpy
+++ b/docs/notebooks/example.pctpy
@@ -8,7 +8,7 @@ how to use the library. We start by defining nested models.
 
 # %%
 
-from pprint import pprint as print
+from pprint import pprint
 from typing import Literal
 
 import pydantic_sweep as ps
@@ -84,7 +84,7 @@ models = ps.initialize(
         ),
     ),
 )
-print(models)
+pprint(models)
 
 # %% [markdown]
 """

--- a/docs/notebooks/intro.pctpy
+++ b/docs/notebooks/intro.pctpy
@@ -18,7 +18,7 @@ section for details or if you want to use your own models.
 """
 
 # %%
-from pprint import pprint as print
+from pprint import pprint
 
 import pydantic_sweep as ps
 
@@ -43,7 +43,7 @@ to assign the values `(1, 2, 3)` to the field `sub.x`, we can run:
 
 # %%
 configs = ps.field("sub.x", [1, 2, 3])
-print(configs)
+pprint(configs)
 
 # %% [markdown]
 """
@@ -54,7 +54,7 @@ code as we move to more complicated configuration setups later.
 
 # %%
 models = ps.initialize(Model, configs)
-print(models)
+pprint(models)
 
 # %% [markdown]
 """
@@ -69,7 +69,7 @@ Sometimes we want to set the same values for all the models. For this, we can us
 
 # %%
 models = ps.initialize(Model, configs, constant=dict(y=0))
-print(models)
+pprint(models)
 
 # %% [markdown]
 """
@@ -86,7 +86,7 @@ models = ps.initialize(
     constant={"sub.x": 0},
     default={"y": 0},
 )
-print(models)
+pprint(models)
 
 # %% [markdown]
 """

--- a/docs/notebooks/models.pctpy
+++ b/docs/notebooks/models.pctpy
@@ -6,9 +6,9 @@ The main intent of the library is for configuring experiments. These are typical
 relatively expensive, so that we want to avoid running a wrong configuration by accident
 at any cost. However, by default `pydantic`'s behavior is unsafe:
 """
-# %%
 
-from pprint import pprint as print
+# %%
+from pprint import pprint
 
 import pydantic
 
@@ -18,10 +18,10 @@ class Model(pydantic.BaseModel):
 
 
 m = Model(y=6)
-print(m)
+pprint(m)
 
 m.x = "not-a-number"
-print(m)
+pprint(m)
 
 # %% [markdown]
 """
@@ -36,6 +36,38 @@ configuration. In particular, {py:class}`pydantic_sweep.BaseModel` configures
 While we check for these settings as part of our {any}`check_model` and 
 {any}`initialize` methods, these checks are not exhaustive and it may be possible to 
 induce unexpected behaviors.
+
+## Model Unions
+
+As mentioned in {doc}`nested`, `pydantic`'s default behavior for matching submodels 
+allows for ambiguity when partial data could match multiple models:
+"""
+
+# %%
+import pydantic
+
+
+class Sub1(pydantic.BaseModel):
+    x: int
+
+
+class Sub2(pydantic.BaseModel):
+    x: int
+
+
+class Model(pydantic.BaseModel):
+    sub: Sub1 | Sub2
+
+
+pprint(Model(sub=dict(x=1)))
+
+# %% [markdown]
+"""
+For the purpose of configuration, this automatic model selection is undesired. To 
+avoid this kind of unsafe behavior, {any}`pydantic_sweep.BaseModel` includes a custom
+[model_validator](https://docs.pydantic.dev/latest/concepts/validators/#model-before
+-validator) that makes sure only one of the models matches. Other validations are 
+left to the core `pydantic` code.
 
 ## Leaf values
 

--- a/docs/notebooks/nested.pctpy
+++ b/docs/notebooks/nested.pctpy
@@ -5,11 +5,16 @@
 So far, we have only considered basic nested models. Configuration gets more interesting
 when there are Union types for sub-models in pydantic. While one could use the previous
 methods, by default `pydantic`'s initialization behavior will match partial
-configurations to the first Model type that matches:
+configurations to the ["best" Model type that matches](
+https://docs.pydantic.dev/latest/concepts/unions/). This
+explicitly allows ambiguity, when multiple could match. Instead, `BaseModel` includes a
+ custom `model_validator` that disallows these kind of unsafe unions:
 """
 
 # %%
-from pprint import pprint as print
+from pprint import pprint
+
+import pydantic
 
 import pydantic_sweep as ps
 
@@ -30,15 +35,21 @@ class Environment(ps.BaseModel):
 
 
 xs = ps.field("method.x", [1, 2])
-models = ps.initialize(Environment, xs)
-print(models)
+
+try:
+    ps.initialize(Environment, xs)
+except pydantic.ValidationError as e:
+    print(e)
 
 # %% [markdown]
 """
-Here the `method.x` value can match either `Method1` or `Method2` and `pydantic` 
-defaults to selecting the first method that matches. To avoid this behavior, 
-it's best to directly configure the methods individually. The {any}`initialize` 
-method provides two ways to do this via the `at` and `to` keyword arguments.
+Here the `method.x` value can match either `Method1` or `Method2`. As suggested by 
+the error, to avoid this behavior either we need to make it explicit which model we 
+want to use. `pydantic` offers a way to do this through [discriminated unions](
+https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions). 
+Alternatively, we can directly initialize the sub-models individually. The 
+{any}`initialize` method provides two ways to do this via the `at` and `to` keyword
+arguments.
  
 The `to` keyword is a shortcut to the following code, which first instantiates a
 `Method1` model and then passes the models as input to the `field` method.
@@ -47,7 +58,7 @@ The `to` keyword is a shortcut to the following code, which first instantiates a
 # %%
 xs = ps.field("x", [1, 2])
 configs_m1 = ps.field("method", ps.initialize(Method1, xs))
-print(ps.initialize(Environment, configs_m1))
+pprint(ps.initialize(Environment, configs_m1))
 
 # %% [markdown]
 """
@@ -56,7 +67,7 @@ For convenience, we can instead directly use the initialize `to` argument.`:
 
 # %%
 configs_m1 = ps.initialize(Method1, xs, to="method")
-print(ps.initialize(Environment, configs_m1))
+pprint(ps.initialize(Environment, configs_m1))
 
 # %% [markdown]
 """
@@ -67,7 +78,7 @@ and then initialize a model `at` the respective field.
 # %%
 zs = ps.field("method.z", [3, 4])
 configs_m2 = ps.initialize(Method2, zs, at="method")
-print(ps.initialize(Environment, configs_m2))
+pprint(ps.initialize(Environment, configs_m2))
 
 # %% [markdown]
 """
@@ -88,7 +99,7 @@ models = ps.initialize(
         ps.config_chain(configs_m1, configs_m2),
     ),
 )
-print(models)
+pprint(models)
 
 # %% [markdown]
 """

--- a/src/pydantic_sweep/_utils.py
+++ b/src/pydantic_sweep/_utils.py
@@ -3,7 +3,7 @@ import itertools
 import random
 import re
 from collections.abc import Iterable, Iterator
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from pydantic_sweep.types import Config, Path, StrictPath
 
@@ -16,6 +16,7 @@ __all__ = [
     "nested_dict_items",
     "nested_dict_replace",
     "normalize_path",
+    "notebook_link",
     "random_seeds",
 ]
 
@@ -230,3 +231,9 @@ def random_seeds(num: int, *, upper: int = 1000) -> list[int]:
         raise ValueError("Upper bound must be positive.")
 
     return random.sample(range(upper), num)
+
+
+def notebook_link(
+    name: Literal["combinations", "example", "intro", "models", "nested"],
+) -> str:
+    return f"https://berkenkamp.me/pydantic_sweep/notebooks/{name}.html"


### PR DESCRIPTION
By default, `pydantic.BaseModel` allows ambiguous matches for nested models (i.e., union types like `sub: Sub1 | Sub2`). This adds a safety check to `ps.BaseModel` to only allow safe matches for models. Closes #6