### PR TITLE
Dependencies versions are relaxed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,13 +3,15 @@
 This page summarizes historic changes in the library. Please also see the
 [release page](https://github.com/befelix/pydantic_sweep/releases)
 
-## Unreleased changes on main branch
-
-- `BaseModel` gained a custom model_validator that ensures ambiguous union types of
-  pydantic BaseModels
-
 
 ## 0.2
+
+### 0.2.1
+- `BaseModel` gained a custom model_validator that guards against ambiguous model
+  selection from union types in nested models.
+- Relaxed version requirements of `pydantic` and `more-itertools`
+
+### 0.2.0
 
 - `DefaultValue` is checked against conflicting settings the same way as normal values
 - Passing `DefaultValue` to the `default`/`constant` argument of `initialize` works as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "more-itertools>=10.5.0",
-    "pydantic>=2.10.3",
+    "more-itertools~=10.1",
+    "pydantic~=2.1",
 ]
 
 [project.urls]

--- a/src/pydantic_sweep/_version.py
+++ b/src/pydantic_sweep/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 if __name__ == "__main__":
     print(__version__)

--- a/uv.lock
+++ b/uv.lock
@@ -1012,7 +1012,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-sweep"
-version = "0.1.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "more-itertools" },
@@ -1040,8 +1040,8 @@ doc = [
 
 [package.metadata]
 requires-dist = [
-    { name = "more-itertools", specifier = ">=10.5.0" },
-    { name = "pydantic", specifier = ">=2.10.3" },
+    { name = "more-itertools", specifier = "~=10.1" },
+    { name = "pydantic", specifier = "~=2.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Instead of requiring the latest version of the dependencies, the library now accepts older ones too.