### PR TITLE
nested dicts for default/constant in initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This page summarizes historic changes in the library. Please also see the
 
 ## 0.3
 
+### 0.3.1
+
+- `initialize` accepts nested dictionaries for `default`/`constant` arguments.
+
+### 0.3.0
+
 - `field` now checks that values are hashable by default. This can be disabled by 
   setting `check=False`.
 - Added `as_hashable` utility to easily compare different configs and pydantic Models.

--- a/docs/notebooks/intro.pctpy
+++ b/docs/notebooks/intro.pctpy
@@ -83,15 +83,17 @@ that does not modify values.
 models = ps.initialize(
     Model,
     ps.field("y", [10, ps.DefaultValue]),
-    constant={"sub.x": 0},
-    default={"y": 0},
+    constant=dict(sub=dict(x=0)),
+    default=dict(y=0),
 )
 pprint.pp(models, width=45)
 
 # %% [markdown]
 """
 Note that while the original `Model` defines `y=6`, here the default value is `0` as 
-defined above.
+defined above. For convenience, it is also possible to provide dot-seperated 
+flattened dictionaries of the form `{"sub.x": 0}` for the `constant` and `default` 
+arguments.
 
 So far, we have encountered the two most important methods in this library: {any}`field`
 and {any}`initialize`. While these functions have a lot more features, so far we 

--- a/src/pydantic_sweep/_model.py
+++ b/src/pydantic_sweep/_model.py
@@ -245,10 +245,11 @@ def initialize(
         The partial config dictionaries that we want to initialize with pydantic.
     constant:
         Constant values that should be initialized for all models. These are safely
-        merged with the parameters.
+        merged with the parameters. Can be either a nested, or a flattened dictionary.
     default:
         Default parameter that are initialized for all models, but may be overwritten by
-        other fields without any error checking.
+        other fields without any error checking. Can be either a nested or a flattened
+        dictionary.
     to:
         If provided, will first initialize the model and then return a
         configuration dictionary that sets the model as the values at the given path.

--- a/src/pydantic_sweep/_utils.py
+++ b/src/pydantic_sweep/_utils.py
@@ -287,9 +287,7 @@ def as_hashable(item: Any, /) -> Hashable:
             )
             return f"pydantic:{item.__class__}:{model_dump}"
         case dict():
-            return frozenset(
-                ((key, as_hashable(value)) for key, value in nested_dict_items(item))
-            )
+            return frozenset((key, as_hashable(value)) for key, value in item.items())
         case set():
             return frozenset(item)
         case list():

--- a/src/pydantic_sweep/_version.py
+++ b/src/pydantic_sweep/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 if __name__ == "__main__":
     print(__version__)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -241,6 +241,14 @@ class TestInitialize:
         )
         assert res == [Model(sub=Sub(x=99), y=10)]
 
+        res = initialize(
+            Model,
+            field("sub.x", [DefaultValue]),
+            constant=dict(y=10),
+            default=dict(sub=dict(x=99)),
+        )
+        assert res == [Model(sub=Sub(x=99), y=10)]
+
     def test_constant(self):
         class Sub(BaseModel):
             x: int
@@ -259,6 +267,10 @@ class TestInitialize:
         assert res == [Model(sub=Sub(x=1), y=10), Model(sub=Sub(x=2), y=10)]
 
         res = initialize(Model, [dict()], constant={"sub.x": 0})
+        assert res == [Model(sub=Sub(x=0))]
+
+        # Provide nested diction config for constant
+        res = initialize(Model, [dict()], constant=dict(sub=dict(x=0)))
         assert res == [Model(sub=Sub(x=0))]
 
         with pytest.raises(TypeError):


### PR DESCRIPTION
This (re-)enables nested dictionaries as an input for the `default` and `constant` keyword arguments in `initialize`.