### PR TITLE
check_model warns on non-hashable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This page summarizes historic changes in the library. Please also see the
 
 ## 0.3
 
+### 0.3.3 (not released)
+- `check_model` now warns on non-hashable type hints
+- `check_model` now explicitly forbids the `arbitrary_types_allowed` pydantic setting.
+
 ### 0.3.2
 
 - Fix for Python 3.10

--- a/src/pydantic_sweep/_model.py
+++ b/src/pydantic_sweep/_model.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import itertools
 import types
-from collections.abc import (
-    Hashable,
-    Iterable
-)
+from collections.abc import Hashable, Iterable
 from functools import partial
-from typing import Any, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Literal, TypeVar, overload
 
 import more_itertools
 import pydantic

--- a/src/pydantic_sweep/_model.py
+++ b/src/pydantic_sweep/_model.py
@@ -4,10 +4,7 @@ import itertools
 import types
 from collections.abc import (
     Hashable,
-    Iterable,
-    MutableMapping,
-    MutableSequence,
-    MutableSet,
+    Iterable
 )
 from functools import partial
 from typing import Any, Literal, TypeAlias, TypeVar, overload
@@ -27,6 +24,7 @@ from pydantic_sweep._utils import (
     normalize_path,
     notebook_link,
     path_to_str,
+    raise_warn_ignore,
 )
 from pydantic_sweep.types import Chainer, Combiner, Config, FieldValue, Path, StrictPath
 
@@ -45,7 +43,6 @@ __all__ = [
 ]
 
 T = TypeVar("T")
-Mutable: TypeAlias = MutableMapping | MutableSequence | MutableSet
 
 
 class BaseModel(
@@ -149,30 +146,34 @@ class DefaultValue(metaclass=NameMetaClass):
         raise TypeError("This is a sentinel value and not meant to be subclassed.")
 
 
+def _field_str(t: Any, /, *, path: StrictPath) -> str:
+    """Field and type info at a given path.
+
+    >>> _field_str(5., path=())
+    'float'
+
+    >>> _field_str(5., path=("a", "b"))
+    'float at field `a.b`'
+    """
+    name = t.__name__ if hasattr(t, "__name__") else t.__class__.__name__
+    field_msg = f" at field `{path_to_str(path)}`" if path else ""
+    return f"{name}{field_msg}"
+
+
 def _check_model_config(
     model: pydantic.BaseModel | type[pydantic.BaseModel], /, *, path: StrictPath
 ) -> None:
     config = model.model_config
     if "extra" not in config or config["extra"] != "forbid":
-        field_msg = f" at field {path_to_str(path)}" if path else ""
-        name = (
-            model.__class__.__name__
-            if isinstance(model, pydantic.BaseModel)
-            else model.__name__
-        )
+        info = _field_str(model, path=path)
         raise ValueError(
-            f"Model {name}{field_msg} must have 'extra=forbid' option enabled. "
+            f"Model {info} must have 'extra=forbid' option enabled. "
             "Without this, typos in field names will be silently ignored."
         )
     if config.get("arbitrary_types_allowed", False):
-        field_msg = f" at field {path_to_str(path)}" if path else ""
-        name = (
-            model.__class__.__name__
-            if isinstance(model, pydantic.BaseModel)
-            else model.__name__
-        )
+        info = _field_str(model, path=path)
         raise ValueError(
-            f"Model {name}{field_msg} must have 'arbitrary_types_allowed=False' set. "
+            f"Model {info} must have 'arbitrary_types_allowed=False' set. "
             "Configuration classes should be built with basic types only to ensure "
             "that the configuration can be checked and serialized reliably."
         )
@@ -182,12 +183,19 @@ def check_model(
     model: pydantic.BaseModel | type[pydantic.BaseModel],
     /,
     *,
-    mutable: Literal["warn", "ignore", "raise"] = "warn",
+    unhashable: Literal["warn", "ignore", "raise"] = "warn",
 ) -> None:
     """Best-effort check that the model has the correct configuration.
 
     This recurses into the models, but there's probably a way to achieve a
     false positive if one tries.
+
+    Parameters
+    ----------
+    model :
+        The model to check.
+    unhashable :
+        The action to take when a non-hashable type hint is encountered in the mode.
     """
     to_check: list[tuple[StrictPath, Any]] = [((), model)]
     checked = set()
@@ -203,6 +211,14 @@ def check_model(
             name = model.__name__
         else:
             # Just a leaf node
+            if isinstance(model, type) and not issubclass(model, Hashable):
+                info = _field_str(model, path=path)
+                raise_warn_ignore(
+                    f"Non-hashable type {info}. These can often create issues with "
+                    f"serialization and can lead to accidental shared state between "
+                    f"different configuration objects.",
+                    action=unhashable,
+                )
             continue
 
         if name in checked:
@@ -525,6 +541,8 @@ def check_unique(
     *models_
         Iterables of models to check for uniqueness. If multiple are passed, they are
         chained together and jointly checked.
+    raise_exception :
+        If ``False``, return a boolean instead of raising an exception on failure.
 
     Raises
     ------

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -146,6 +146,27 @@ class TestCheckModel:
         with pytest.raises(ValueError):
             check_model(A())
 
+    def test_non_hashable(self):
+        """Note: mutable types are not hashable."""
+        class A(BaseModel):
+            x: set
+
+        class B(BaseModel):
+            a: A
+
+        check_model(A, unhashable="ignore")
+        check_model(B, unhashable="ignore")
+        with pytest.warns(UserWarning, match="`a.x`"):
+            check_model(B)
+        with pytest.raises(ValueError, match="`a.x`"):
+            check_model(B, unhashable="raise")
+
+        class A(BaseModel):
+            y: list
+
+        with pytest.warns(UserWarning, match="`y`"):
+            check_model(A, unhashable="warn")
+
 
 class TestField:
     def test_invalid_path(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -148,6 +148,7 @@ class TestCheckModel:
 
     def test_non_hashable(self):
         """Note: mutable types are not hashable."""
+
         class A(BaseModel):
             x: set
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import pydantic
 import pytest
 
 from pydantic_sweep._utils import (
+    RaiseWarnIgnore,
     as_hashable,
     merge_nested_dicts,
     nested_dict_at,
@@ -12,6 +13,7 @@ from pydantic_sweep._utils import (
     nested_dict_get,
     nested_dict_replace,
     normalize_path,
+    raise_warn_ignore,
     random_seeds,
 )
 
@@ -190,3 +192,22 @@ def test_random_seeds():
         random_seeds(-1)
     with pytest.raises(ValueError):
         random_seeds(1, upper=0)
+
+
+def test_raise_warn_ignore():
+    class CustomException(Exception):
+        pass
+
+    class CustomWarning(UserWarning):
+        pass
+
+    raise_warn_ignore("blub", action="ignore")
+    with pytest.raises(CustomException, match="blub1"):
+        raise_warn_ignore("blub1", action="raise", exception=CustomException)
+    with pytest.warns(CustomWarning, match="blub2"):
+        raise_warn_ignore("blub2", action="warn", warning=CustomWarning)
+
+    with pytest.raises(ValueError, match="raise, warn, ignore"):
+        raise_warn_ignore("blub", action="OWEH")
+
+    raise_warn_ignore("blub", action=RaiseWarnIgnore.IGNORE)


### PR DESCRIPTION
The check_model function now warns on non-hashable types by default. This is configurable, so that non-hashable values can also be ignored or raise an exceptions.