### PR TITLE
check_model considers subtypes

### DIFF
--- a/src/pydantic_sweep/types.py
+++ b/src/pydantic_sweep/types.py
@@ -28,7 +28,7 @@ Fields should be hashable (and therefore immutable) values. That makes them safe
 use in a configuration, since unlike mutable types they can not be modified inplace.
 """
 
-Config: TypeAlias = dict[str, Union[FieldValue, "Config"]]
+Config: TypeAlias = dict[str, Union["FieldValue", "Config"]]
 """A nested config dictionary for configurations."""
 
 


### PR DESCRIPTION
Previously, `check_model` would ignore complex subtypes such as `list[Model1]` or union types. This PR extends the existing functionality to extensively test these types.