### PR TITLE
Allow more flexible configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This page summarizes historic changes in the library. Please also see the
 - Added `pydantic_sweep.convert` to convert between json, yaml and Python code
   dumps of pydantic Models. This is also an entrypoint that can be executed as
   `python -m pydantic_sweep.convert source target --model 'path.to.Model'`
+- `initialize` now accepts any mixture of `str`, tuple, and dot-separated keys for
+  `default` and `constant` values.
 
 ### 0.3.3
 - `check_model` now warns on non-hashable type hints (can be configured)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,8 @@ nitpick_ignore = [
     ("py:class", "pydantic_sweep.types.Path"),
     ("py:class", "pydantic_sweep.types.StrictPath"),
     ("py:class", "pydantic_sweep.types.FieldValue"),
-    ("py:class", "pydantic_sweep.types.ModelType"),
+    ("py:class", "pydantic_sweep.types.BaseModelT"),
+    ("py:class", "pydantic_sweep.types.FlexibleConfig"),
 ]
 napoleon_use_rtype = False
 

--- a/src/pydantic_sweep/__init__.py
+++ b/src/pydantic_sweep/__init__.py
@@ -27,7 +27,6 @@ __all__ = [
     "config_product",
     "config_roundrobin",
     "config_zip",
-    "convert",
     "field",
     "initialize",
     "model_diff",

--- a/src/pydantic_sweep/types.py
+++ b/src/pydantic_sweep/types.py
@@ -10,6 +10,7 @@ __all__ = [
     "Combiner",
     "Config",
     "FieldValue",
+    "FlexibleConfig",
     "Path",
     "StrictPath",
 ]
@@ -18,7 +19,7 @@ __all__ = [
 StrictPath: TypeAlias = tuple[str, ...]
 """A tuple-path of keys for a pydantic model."""
 
-Path: TypeAlias = Iterable[str] | str
+Path: TypeAlias = Union[Iterable[str], str, "StrictPath"]
 """Anything that can be converted to a tuple-path (str or iterable of str)."""
 
 FieldValue: TypeAlias = Hashable | pydantic.BaseModel
@@ -31,6 +32,10 @@ use in a configuration, since unlike mutable types they can not be modified inpl
 Config: TypeAlias = dict[str, Union["FieldValue", "Config"]]
 """A nested config dictionary for configurations."""
 
+FlexibleConfig: TypeAlias = Union[
+    dict["Path", Union["FieldValue", "FlexibleConfig"]], "Config"
+]
+"""A flexible config that allows any Path."""
 
 T = TypeVar("T")
 
@@ -47,5 +52,5 @@ class Chainer(Protocol[T]):
     def __call__(self, *configs: Iterable[T]) -> Iterable[T]: ...
 
 
-ModelType = TypeVar("ModelType", bound=pydantic.BaseModel)
+BaseModelT = TypeVar("BaseModelT", bound=pydantic.BaseModel)
 """TypeVar for a pydantic BaseModel."""


### PR DESCRIPTION
Instead of only accepting `dict[str, FieldValue]` for default/contant values, we now accept any wild combination of nested dictionaries with str, dot-separated, or tuple keys.