### PR TITLE
Fix model_replace for Union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This page summarizes historic changes in the library. Please also see the
 
 ## 0.3
 
+### 0.3.6
+
+- Fix `model_replace` for Union types
+
 ### 0.3.5
 
 - Type hints have improved to avoid false positives on the user side.

--- a/src/pydantic_sweep/_model.py
+++ b/src/pydantic_sweep/_model.py
@@ -417,7 +417,7 @@ def model_replace(model: BaseModelT, *, values: FlexibleConfig) -> BaseModelT:
             f"Expected dictionary for input 'values', got '{type(values)}'."
         )
 
-    model_dump = model.model_dump(exclude_defaults=True)
+    model_dump = model.model_dump()
 
     # We remove any paths with DefaultValue both from the model dump and values,
     # so that pydantic uses whatever was the default.

--- a/src/pydantic_sweep/_version.py
+++ b/src/pydantic_sweep/_version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 if __name__ == "__main__":
     print(__version__)


### PR DESCRIPTION
Pydantic's exclude_defaults will also exclude fields that have literal default values that are needed to uniquely determine union types.