### PR TITLE
Version made static

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,12 +5,17 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt \
     export DEBIAN_FRONTEND="noninteractive" \
     && apt update \
     && apt install -y \
-    # Basic utilities
-    vim \
-    git \
-    curl \
-    wget \
-    build-essential
+        # Basic utilities
+        vim \
+        git \
+        curl \
+        wget \
+        build-essential \
+        # locale support
+        locales \
+    # setup locales
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen
 
 RUN mkdir /uv && chmod 777 /uv
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check tag
         shell: bash
         run: |
-            PACKAGE_VERSION=$(uv run --quiet --script src/pydantic_sweep/_version.py)
+            PACKAGE_VERSION=$(uv version --short)
             RELEASE_VERSION=${GITHUB_REF#refs/*/}
 
             if [ "$RELEASE_VERSION" != "v$PACKAGE_VERSION" ];

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,23 +3,19 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import importlib.util
-import sys
 from pathlib import Path
 
+import tomllib
+
 PROJECT_ROOT = Path(__file__).parents[1]
-MODULE_ROOT = PROJECT_ROOT.joinpath("src", "pydantic_sweep")
-
-sys.path.append(str(PROJECT_ROOT))
 
 
-def import_file(file: Path, /):
-    """Import a file directly."""
-    assert file.exists()
-    spec = importlib.util.spec_from_file_location(file.stem, file)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+def get_version() -> str:
+    """Get the version from the pyproject.toml file."""
+    with open(PROJECT_ROOT / "pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    return pyproject["project"]["version"]
 
 
 # -- Project information -----------------------------------------------------
@@ -27,7 +23,7 @@ def import_file(file: Path, /):
 
 project = "pydantic_sweep"
 author = "Felix Berkenkamp"
-release = import_file(MODULE_ROOT / "_version.py").__version__
+release = get_version()
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "pydantic-sweep"
+version = "0.3.6"
 description = "Programmatic parameter sweeps for pydantic."
 readme = "README.md"
 license = "MPL-2.0"
-dynamic = ["version"]
 authors = [
     { name = "Felix Berkenkamp" }
 ]
@@ -38,9 +38,6 @@ yaml = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.hatch.version]
-path = "src/pydantic_sweep/_version.py"
 
 [dependency-groups]
 dev = [

--- a/src/pydantic_sweep/__init__.py
+++ b/src/pydantic_sweep/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 from . import types
 from ._model import (
     BaseModel,
@@ -14,7 +16,9 @@ from ._model import (
     model_replace,
 )
 from ._utils import as_hashable, model_diff, random_seeds
-from ._version import __version__
+
+__version__ = version("pydantic-sweep")
+del version
 
 __all__ = [
     "BaseModel",

--- a/src/pydantic_sweep/_version.py
+++ b/src/pydantic_sweep/_version.py
@@ -1,4 +1,0 @@
-__version__ = "0.3.6"
-
-if __name__ == "__main__":
-    print(__version__)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+from importlib.metadata import version
+
+import pydantic_sweep as ps
+
+
+def test_version():
+    assert isinstance(ps.__version__, str)
+    _, _, _ = ps.__version__.split(".")
+    assert ps.__version__ == version("pydantic-sweep")

--- a/uv.lock
+++ b/uv.lock
@@ -1154,6 +1154,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-sweep"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "more-itertools" },


### PR DESCRIPTION
The new `uv version` command makes it a lot more comfy to have a static version in the pyproject.toml file. Avoids some hacky code in the documentation config.